### PR TITLE
Fix typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 **/xcuserdata/*
 .DS_Store
 **/.DS_Store
-**/constents.xcworkspacedata
+**/contents.xcworkspacedata
 node_modules/
 OldArchitecture/
 NewArchitecture/


### PR DESCRIPTION
Hello 👋.

I believe that there is a typo on line 5: `constents` should be `contents`.